### PR TITLE
adds option to have comma separation (french and other languages)

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -560,7 +560,6 @@ impl Formatter {
             idx += 1;
             written += 1; // increment counter
 
-
             if byte.is_ascii_digit() {
                 digits += 1;
                 thou += 1;


### PR DESCRIPTION
This does seem the regress performance a bit, note that running benchmark twice gave significantly different results on my computer... (but each time with some regressions)

Benchmarking on my computer for this PR:
```rust
     Running bench.rs (target/release/deps/numfmt_benchmarks-c34caa3adfdc86b5)
numfmt default zero     time:   [33.368 ns 33.385 ns 33.403 ns]
                        change: [+0.8768% +1.1387% +1.3964%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe

numfmt cached zero      time:   [2.2635 ns 2.2685 ns 2.2736 ns]
                        change: [+0.4760% +0.7272% +0.9739%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  12 (12.00%) high mild
  3 (3.00%) high severe

std zero                time:   [41.733 ns 41.819 ns 41.918 ns]
                        change: [+1.3226% +1.7623% +2.2284%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

numfmt default _1234    time:   [129.10 ns 129.34 ns 129.62 ns]
                        change: [-0.8351% -0.5640% -0.2967%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

numfmt cached _1234     time:   [81.148 ns 81.278 ns 81.396 ns]
                        change: [+1.9613% +2.2701% +2.5776%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild

std _1234               time:   [79.693 ns 80.016 ns 80.329 ns]
                        change: [+6.4334% +6.8675% +7.2924%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

numfmt default lrgdec   time:   [139.88 ns 140.33 ns 140.75 ns]
                        change: [-2.8866% -2.3800% -1.9372%] (p = 0.00 < 0.05)
                        Performance has improved.

numfmt cached lrgdec    time:   [93.500 ns 93.631 ns 93.792 ns]
                        change: [-1.3219% -1.1511% -0.9652%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

std lrgdec              time:   [112.80 ns 112.88 ns 112.97 ns]
                        change: [-3.3537% -3.0926% -2.8167%] (p = 0.00 < 0.05)
                        Performance has improved.

numfmt default sn       time:   [181.31 ns 181.59 ns 181.93 ns]
                        change: [-1.8346% -1.6280% -1.3481%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

numfmt cached sn        time:   [131.92 ns 132.09 ns 132.34 ns]
                        change: [+0.9991% +1.1885% +1.3928%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

std sn                  time:   [260.52 ns 260.73 ns 260.93 ns]
                        change: [-0.5715% -0.3167% -0.1062%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```
Bench for main : 
```rust
numfmt default zero     time:   [32.967 ns 33.059 ns 33.158 ns]
                        change: [-6.0488% -5.1831% -4.3027%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe

numfmt cached zero      time:   [2.2459 ns 2.2503 ns 2.2545 ns]
                        change: [+0.3476% +0.5324% +0.7034%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

std zero                time:   [40.684 ns 40.873 ns 41.080 ns]
                        change: [-1.7038% -1.2958% -0.8568%] (p = 0.00 < 0.05)
                        Change within noise threshold.

numfmt default _1234    time:   [130.21 ns 130.62 ns 131.06 ns]
                        change: [+0.8531% +1.0624% +1.3380%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

numfmt cached _1234     time:   [78.864 ns 79.089 ns 79.326 ns]
                        change: [-0.7862% -0.4996% -0.1658%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

std _1234               time:   [73.907 ns 74.080 ns 74.291 ns]
                        change: [-7.1703% -6.8100% -6.4341%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

numfmt default lrgdec   time:   [143.88 ns 145.01 ns 146.32 ns]
                        change: [+2.9165% +3.3563% +3.8937%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe

numfmt cached lrgdec    time:   [94.915 ns 95.027 ns 95.134 ns]
                        change: [+0.3181% +0.7374% +1.1036%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

std lrgdec              time:   [115.00 ns 115.53 ns 116.03 ns]
                        change: [-0.4650% +0.2277% +0.8501%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) low mild

numfmt default sn       time:   [184.24 ns 184.36 ns 184.50 ns]
                        change: [-1.3577% -1.1571% -0.9767%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

numfmt cached sn        time:   [130.04 ns 130.29 ns 130.60 ns]
                        change: [-1.0067% -0.8446% -0.6675%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

std sn                  time:   [260.57 ns 260.99 ns 261.36 ns]
                        change: [-8.9069% -8.6678% -8.4128%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
```